### PR TITLE
Approve Dependabot PRs before enabling auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Approve Dependabot PRs for semver-minor and semver-patch updates
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge Dependabot PRs for semver-minor updates
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
Branch protection on `main` requires one approving review. `gh pr merge --auto` only queues the merge and waits for protection rules, so Dependabot PRs stayed open with no reviewer.

This adds a `gh pr review --approve` step for semver-minor and semver-patch updates before the existing auto-merge steps. The `github-actions[bot]` approval satisfies the required review count.

Requires "Allow auto-merge" to be enabled in the repository settings, which is now done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated approval was added for Dependabot pull requests containing minor or patch updates.
  * Approved updates continue through the existing automatic merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->