### PR TITLE
Add tests-passed aggregator job for branch protection

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,3 +99,14 @@ jobs:
           disable_search: true
           fail_ci_if_error: false
         continue-on-error: true
+
+  tests-passed:
+    runs-on: ubuntu-latest
+    name: tests-passed
+    needs: [ test, coverage ]
+    if: always()
+
+    steps:
+      - name: Fail if any test job did not succeed
+        if: ${{ needs.test.result != 'success' || needs.coverage.result != 'success' }}
+        run: exit 1


### PR DESCRIPTION
Matrix job names in `run-tests.yml` embed the PHP and Laravel versions. A required-check list built from those names goes stale whenever the matrix changes: new jobs are not required, and removed jobs leave a required check that never reports and blocks every PR.

This adds a `tests-passed` job that depends on the `test` matrix and the `coverage` job. It runs with `if: always()` so a failed or cancelled upstream job produces a failing check instead of a skipped one, and it fails when either dependency did not succeed.

Branch protection on `main` now requires only `tests-passed`. Together with #121 and repository auto-merge, Dependabot PRs merge only after the full test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated workflow status reporting to clearly fail when tests or coverage checks do not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->