### PR TITLE
Stop Rector from renaming Blade::component() in the provider

### DIFF
--- a/config/cookies_consent.php
+++ b/config/cookies_consent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     /**
      * This prefix will be applied when setting and getting all cookies.

--- a/rector.php
+++ b/rector.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use RectorLaravel\Rector\If_\ThrowIfRector;
 use RectorLaravel\Set\LaravelSetList;
-use RectorLaravel\Set\LaravelSetProvider;
 
 return RectorConfig::configure()
-    ->withSetProviders(LaravelSetProvider::class)
     ->withSets([
         LaravelSetList::LARAVEL_ARRAYACCESS_TO_METHOD_CALL,
         LaravelSetList::LARAVEL_ARRAY_STR_FUNCTION_TO_STATIC_CALL,
@@ -36,6 +35,9 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         ThrowIfRector::class,
+        // The Laravel 7.0 set renames Blade::component() to aliasComponent(), assuming the
+        // pre-7 path-based signature. The provider registers class-based components.
+        RenameMethodRector::class => [__DIR__ . '/src/LaravelCookiesConsentServiceProvider.php'],
     ])
     ->withPreparedSets(
         deadCode: true,

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Route;

--- a/src/Facades/LaravelCookiesConsent.php
+++ b/src/Facades/LaravelCookiesConsent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SciFY\LaravelCookiesConsent\Facades;
 
 use Illuminate\Support\Facades\Facade;

--- a/src/LaravelCookiesConsent.php
+++ b/src/LaravelCookiesConsent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SciFY\LaravelCookiesConsent;
 
 class LaravelCookiesConsent {}

--- a/src/View/Components/LaravelCookiesConsent.php
+++ b/src/View/Components/LaravelCookiesConsent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SciFY\LaravelCookiesConsent\View\Components;
 
 use Illuminate\View\Component;

--- a/src/View/Components/LaravelCookiesConsentPage.php
+++ b/src/View/Components/LaravelCookiesConsentPage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SciFY\LaravelCookiesConsent\View\Components;
 
 use Illuminate\View\Component;

--- a/src/View/Components/LaravelCookiesConsentScripts.php
+++ b/src/View/Components/LaravelCookiesConsentScripts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace SciFY\LaravelCookiesConsent\View\Components;
 
 use Illuminate\View\Component;

--- a/tests/CookiesControllerTest.php
+++ b/tests/CookiesControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Routing\Router;
+
 it('saves cookie consent selection and returns success JSON response', function (): void {
     $response = $this->postJson('/guard-settings/save', [
         'strictly_necessary' => true,
@@ -130,7 +132,7 @@ it('accepts region-qualified locales', function (): void {
 });
 
 it('registers the package routes inside the web middleware group', function (): void {
-    $saveRoute = app('router')->getRoutes()->getByAction('SciFY\LaravelCookiesConsent\Http\Controllers\CookiesController@save_cookies_consent_selection');
+    $saveRoute = resolve(Router::class)->getRoutes()->getByAction('SciFY\LaravelCookiesConsent\Http\Controllers\CookiesController@save_cookies_consent_selection');
 
     expect($saveRoute)->not->toBeNull()
         ->and($saveRoute->gatherMiddleware())->toContain('web');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use SciFY\LaravelCookiesConsent\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace SciFY\LaravelCookiesConsent\Tests;
 
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\Facades\File;
 use Orchestra\Testbench\TestCase as Orchestra;
 use RuntimeException;
@@ -19,7 +20,7 @@ class TestCase extends Orchestra {
      * EncryptCookies middleware needs an application key.
      */
     protected function defineEnvironment($app): void {
-        $app['config']->set('app.key', 'base64:' . base64_encode(random_bytes(32)));
+        $app->make(Repository::class)->set('app.key', 'base64:' . base64_encode(random_bytes(32)));
     }
 
     protected function getPackageProviders($app): array {


### PR DESCRIPTION
Running `composer lint` rewrote the three `Blade::component()` calls in the service provider to `Blade::aliasComponent()`, which broke every application boot with "The directive name [SciFY\...\LaravelCookiesConsent] is not valid". The rename comes from Rector-Laravel's Laravel 7.0 upgrade set (`config/sets/laravel70.php`), which assumes the pre-7 path-based signature. `RenameMethodRector` matches on method name only, so it cannot tell the two signatures apart.

Changes:

- `rector.php`: skip `RenameMethodRector` for `src/LaravelCookiesConsentServiceProvider.php`, with a comment explaining why.
- `rector.php`: remove `withSetProviders(LaravelSetProvider::class)`. Rector prints a deprecation for it on every run; `withComposerBased(laravel: true)` already loads the Laravel sets.
- The rest of the `composer lint` output, so the working tree stays clean after a lint run: `declare(strict_types=1)` in eight files (`SafeDeclareStrictTypesRector`) and container resolution by class instead of string in two tests.

A second `composer lint` run reports no changes and no warnings. Pest 44, PHPStan level 9 and Pint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enabled strict type checking across key application, routing, configuration, and view component files.
  - Updated automated code modernization rules to preserve required method naming behavior for the service provider.

- **Tests**
  - Improved test setup and service resolution for more reliable application configuration and route middleware checks.
  - Enabled strict type checking across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->